### PR TITLE
enable workflow tox

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     -   id: debug-statements
     -   id: name-tests-test
         args: ['--django']
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/PyCQA/flake8
     rev: 3.8.4
     hooks:
     -   id: flake8


### PR DESCRIPTION
Smol change to use the Github flake8 package instead of the Gitlab version because I don't have a Gitlab account. 

I manually enabled the Github actions for this fork below they are running and passing as expected. 